### PR TITLE
Use ClientBuilder with default headers

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -54,8 +54,6 @@ impl Supabase {
         let response: Response = self
             .client
             .post(&request_url)
-            .header("apikey", &self.api_key)
-            .header("Content-Type", "application/json")
             .json(&Password {
                 email: email.to_string(),
                 password: password.to_string(),
@@ -71,8 +69,6 @@ impl Supabase {
         let response: Response = self
             .client
             .post(&request_url)
-            .header("apikey", &self.api_key)
-            .header("Content-Type", "application/json")
             .json(&RefreshToken {
                 refresh_token: refresh_token.to_string(),
             })
@@ -87,8 +83,6 @@ impl Supabase {
         let response: Response = self
             .client
             .post(&request_url)
-            .header("apikey", &self.api_key)
-            .header("Content-Type", "application/json")
             .bearer_auth(token)
             .send()
             .await?;
@@ -104,8 +98,6 @@ impl Supabase {
         let response: Response = self
             .client
             .post(&request_url)
-            .header("apikey", &self.api_key)
-            .header("Content-Type", "application/json")
             .json(&Password {
                 email: email.to_string(),
                 password: password.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod db;
 pub struct Supabase {
     client: Client,
     url: String,
-    api_key: String,
     jwt: String,
     bearer_token: Option<String>,
     db: postgrest::Postgrest,


### PR DESCRIPTION
Make use of default headers instead of setting the `apikey` header for every request. This change also makes the apikey field useless.